### PR TITLE
Add 'Open with Codeanywhere' badge to README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,8 @@
 # Werkomgeving Filius
 
 [![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/emmauscollege/filius)
+[![Open in Codeanywhere](https://codeanywhere.com/img/open-in-codeanywhere-btn.svg)](https://app.codeanywhere.com/#https://github.com/emmauscollege/filius)
+
 
 Met deze repository kun je in GitPod aan de slag in Filius, het programma om te leren hoe computers met elkaar communiceren.
 


### PR DESCRIPTION
With Codeanywhere, developers and contributors can instantly launch a cloud or local IDE with a pre-configured remote development environment. One can work in the cloud or locally, and it ensures all contributors have access to the same, ready-to-use dev env.